### PR TITLE
Fix: Resolve compilation errors in ControladorAdmin and Colegio.

### DIFF
--- a/GestionColegio/modelo/Colegio.java
+++ b/GestionColegio/modelo/Colegio.java
@@ -257,6 +257,23 @@ public class Colegio {
         cursoDAO.actualizarListaCursos(todosCursos);
     }
     
+    // Methods to retrieve lists of entities directly from DAOs
+    public ArrayList<Curso> listarCursos() throws IOException, ClassNotFoundException {
+        return cursoDAO.listarCursos();
+    }
+
+    public ArrayList<Asignatura> listarAsignaturas() throws IOException, ClassNotFoundException {
+        return asignaturaDAO.listarAsignaturas();
+    }
+
+    public ArrayList<Estudiante> listarEstudiantes() throws IOException, ClassNotFoundException {
+        return estudianteDAO.listarEstudiantes();
+    }
+
+    public ArrayList<Profesor> listarProfesores() throws IOException, ClassNotFoundException {
+        return profesorDAO.listarProfesores();
+    }
+    
     public Profesor buscarProfesor(int cod) throws IOException, ClassNotFoundException {
         ArrayList<Profesor> profesores = profesorDAO.listarProfesores();
         for (Profesor profesor : profesores) {


### PR DESCRIPTION
Corrected issues causing "cannot find symbol" and "incompatible types" errors related to list-retrieval methods.

- Updated `Colegio.java` to ensure the presence and correct signature of:
  - `public ArrayList<Curso> listarCursos()`
  - `public ArrayList<Asignatura> listarAsignaturas()`
  - `public ArrayList<Estudiante> listarEstudiantes()`
  - `public ArrayList<Profesor> listarProfesores()` These methods now correctly return ArrayLists of their respective entities by calling the DAOs and declare appropriate exceptions.

- Verified `ControladorAdmin.java` to ensure it calls these updated ArrayList-returning methods from `Colegio.java` for functionalities like `getCursos()`, `getAsignaturas()`, `existeCurso()`, `existeCodigoEstudiante()`, and `existeAsignaturaGlobalmente()`.

These changes should address the compilation errors you reported regarding method resolution and type compatibility between ControladorAdmin and Colegio.