### PR TITLE
Refactor: Translate comments and internal names to Spanish

### DIFF
--- a/GestionColegio/controlador/ControladorDocente.java
+++ b/GestionColegio/controlador/ControladorDocente.java
@@ -20,23 +20,23 @@ public class ControladorDocente extends ControladorGeneral {
         if (this.profesor == null) {
             System.err.println("Advertencia: Profesor con código " + codigoProfesor + " no encontrado.");
         } else {
-            // If professor and their assigned course exist, refresh the course to its latest state
+            // Si el profesor y su curso asignado existen, actualizar el curso a su estado más reciente
             if (this.profesor.getCurso() != null) {
-                Curso cursoOriginalStale = this.profesor.getCurso();
-                // Fetch the LATEST version of this course from the central source of truth (cursos.dat via Colegio)
-                Curso cursoActualizado = this.colegio.buscarCurso(cursoOriginalStale.getGrado(), cursoOriginalStale.getGrupo());
+                Curso cursoOriginalObsoleto = this.profesor.getCurso();
+                // Obtener la ÚLTIMA versión de este curso desde la fuente central de verdad (cursos.dat a través de Colegio)
+                Curso cursoActualizado = this.colegio.buscarCurso(cursoOriginalObsoleto.getGrado(), cursoOriginalObsoleto.getGrupo());
                 
                 if (cursoActualizado != null) {
-                    // Replace the (potentially) stale Curso object in the loaded Profesor instance
-                    // with the fresh one.
+                    // Reemplazar el objeto Curso (potencialmente) obsoleto en la instancia cargada del Profesor
+                    // con el actualizado.
                     this.profesor.setCurso(cursoActualizado); 
                 } else {
-                    // The course assigned to the professor was not found in cursos.dat. This is an inconsistency.
-                    System.err.println("Advertencia: El curso " + cursoOriginalStale.getGrado() + "-" + cursoOriginalStale.getGrupo() + 
+                    // El curso asignado al profesor no se encontró en cursos.dat. Esto es una inconsistencia.
+                    System.err.println("Advertencia: El curso " + cursoOriginalObsoleto.getGrado() + "-" + cursoOriginalObsoleto.getGrupo() + 
                                        " asignado al profesor " + codigoProfesor + 
                                        " no fue encontrado en la base de datos de cursos. El profesor podría estar mostrando información de curso desactualizada o incorrecta.");
-                    // Not setting this.profesor.setCurso(null) here to allow viewing of potentially stale data if course was deleted,
-                    // but operations requiring course consistency might fail later. Error log is important.
+                    // No se establece this.profesor.setCurso(null) aquí para permitir la visualización de datos potencialmente obsoletos si el curso fue eliminado,
+                    // pero las operaciones que requieren consistencia del curso podrían fallar más tarde. El registro de errores es importante.
                 }
             }
         }
@@ -55,10 +55,10 @@ public class ControladorDocente extends ControladorGeneral {
         }
 
         try {
-            // Pass the actual Estudiante object to the professor's method
+            // Pasar el objeto Estudiante real al método del profesor
             this.profesor.calificarEstudiante(estudianteAcalificar, nombreAsignatura, nombreCalificacion, nota, periodo, fecha);
             
-            // Persist the changes made to the student
+            // Persistir los cambios realizados en el estudiante
             colegio.guardarCambiosEstudiante(estudianteAcalificar); // Throws IOException, CNFE
 
         } catch (IllegalStateException | IllegalArgumentException e) {

--- a/GestionColegio/modelo/Asignatura.java
+++ b/GestionColegio/modelo/Asignatura.java
@@ -55,21 +55,21 @@ public class Asignatura implements Descriptible, Serializable {
     
 
     /**
-     * @return the nombre
+     * @return el nombre
      */
     public String getNombre() {
         return nombre;
     }
 
     /**
-     * @param nombre the nombre to set
+     * @param nombre el nombre a establecer
      */
     public void setNombre(String nombre) {
         this.nombre = nombre;
     }
 
     /**
-     * @return the calificaciones
+     * @return las calificaciones
      */
     public ArrayList<Calificacion> getCalificaciones() {
         if (this.calificaciones == null) {
@@ -79,7 +79,7 @@ public class Asignatura implements Descriptible, Serializable {
     }
 
     /**
-     * @param calificaciones the calificaciones to set
+     * @param calificaciones las calificaciones a establecer
      */
     public void setCalificaciones(ArrayList<Calificacion> calificaciones) {
         this.calificaciones = calificaciones;

--- a/GestionColegio/modelo/Curso.java
+++ b/GestionColegio/modelo/Curso.java
@@ -83,15 +83,15 @@ public class Curso implements Descriptible, Serializable {
         if (this.asignaturas == null) {
             this.asignaturas = new ArrayList<>();
         }
-        if (asignatura != null && asignatura.getNombre() != null) { // Ensure asignatura and its name are not null
-            boolean alreadyExists = false;
+        if (asignatura != null && asignatura.getNombre() != null) { // Asegurar que la asignatura y su nombre no sean nulos
+            boolean yaExiste = false;
             for (Asignatura existingAsig : this.asignaturas) {
                 if (existingAsig.getNombre().equalsIgnoreCase(asignatura.getNombre())) {
-                    alreadyExists = true;
+                    yaExiste = true;
                     break;
                 }
             }
-            if (!alreadyExists) {
+            if (!yaExiste) {
                 this.asignaturas.add(asignatura);
             }
         }

--- a/GestionColegio/modelo/Profesor.java
+++ b/GestionColegio/modelo/Profesor.java
@@ -28,9 +28,9 @@ public class Profesor extends Persona implements Serializable {
     }
     
     public void calificarEstudiante(Estudiante estudiante, String nombreAsignatura, String nombreCalificacion, float nota, int periodo, LocalDate fecha) {
-        // The check for this.curso might still be relevant if a professor can only calify students
-        // if they are generally assigned to any course, even if the student is passed directly.
-        // However, the explicit lookup of the student via this.curso is removed.
+        // La comprobación de this.curso aún podría ser relevante si un profesor solo puede calificar estudiantes
+        // si generalmente están asignados a algún curso, incluso si el estudiante se pasa directamente.
+        // Sin embargo, se elimina la búsqueda explícita del estudiante a través de this.curso.
         // if (this.curso == null) {
         //     throw new IllegalStateException("El profesor no tiene un curso asignado y no puede calificar.");
         // }

--- a/GestionColegio/vista/MenuDocente.java
+++ b/GestionColegio/vista/MenuDocente.java
@@ -54,7 +54,7 @@ public class MenuDocente extends javax.swing.JFrame {
         layout.setAutoCreateGaps(true);
         layout.setAutoCreateContainerGaps(true);
 
-        // Horizontal Group
+        // Grupo Horizontal
         layout.setHorizontalGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addComponent(lblEstudiante)
@@ -132,7 +132,7 @@ public class MenuDocente extends javax.swing.JFrame {
             } else {
                  areaInfoCursoEstudiantes.append("\nNo hay estudiantes matriculados en este curso.");
             }
-            // Populate subjects for the teacher's course
+            // Poblar asignaturas del curso del docente
             cmbAsignaturas.removeAllItems();
             if (profesor.getCurso() != null && profesor.getCurso().getASignaturas() != null && !profesor.getCurso().getASignaturas().isEmpty()) {
                 for (Asignatura asig : profesor.getCurso().getASignaturas()) {
@@ -159,7 +159,7 @@ public class MenuDocente extends javax.swing.JFrame {
         if (!habilitar) {
             cmbAsignaturas.removeAllItems();
         } else {
-            // Ensure cmbAsignaturas is populated if it was cleared but should be enabled
+            // Asegurar que cmbAsignaturas se pueble si fue limpiado pero debería estar habilitado
             if (cmbAsignaturas.getItemCount() == 0 && curso != null && curso.getASignaturas() != null && !curso.getASignaturas().isEmpty()) {
                 for (Asignatura asig : curso.getASignaturas()) {
                     cmbAsignaturas.addItem(asig);
@@ -167,10 +167,10 @@ public class MenuDocente extends javax.swing.JFrame {
             }
         }
         
-        // Disable student combobox if no students
+        // Deshabilitar combobox de estudiantes si no hay estudiantes
         cmbEstudiantes.setEnabled(profesor != null && curso != null && curso.getEstudiantes() != null && !curso.getEstudiantes().isEmpty());
 
-        // If no students, also disable subject related controls
+        // Si no hay estudiantes, deshabilitar también los controles relacionados con las asignaturas
         if (cmbEstudiantes.getItemCount() == 0) {
             cmbAsignaturas.setEnabled(false);
             btnAgregarCalificacion.setEnabled(false);
@@ -220,7 +220,7 @@ public class MenuDocente extends javax.swing.JFrame {
             }
         });
         
-        // Initial call to set component states correctly after everything is loaded.
+        // Llamada inicial para establecer los estados de los componentes correctamente después de que todo esté cargado.
         actualizarEstadoControlesAsignatura(); 
     }
 }


### PR DESCRIPTION
I translated various English comments and a few internal variable names to Spanish across several files to improve code consistency and readability for Spanish-speaking developers.

Files affected:
- `GestionColegio/vista/MenuDocente.java`: Translated comments related to UI logic and component states.
- `GestionColegio/controlador/ControladorDocente.java`: Translated comments detailing logic for course data synchronization and student grading. Renamed `cursoOriginalStale` to `cursoOriginalObsoleto`.
- `GestionColegio/modelo/Profesor.java`: Translated comments within a commented-out code block.
- `GestionColegio/modelo/Curso.java`: Translated a comment and renamed `alreadyExists` to `yaExiste`.
- `GestionColegio/modelo/Asignatura.java`: Translated Javadoc comments for getters and setters.

This change aims to maintain a more consistent Spanish-language environment within the codebase.